### PR TITLE
Remove `redirect_stderr` from supervisor configs

### DIFF
--- a/common/documentserver/supervisor/onlyoffice-documentserver-converter.conf
+++ b/common/documentserver/supervisor/onlyoffice-documentserver-converter.conf
@@ -7,4 +7,3 @@ stdout_logfile=/var/log/onlyoffice/documentserver/converter/out.log
 stderr_logfile=/var/log/onlyoffice/documentserver/converter/err.log
 autostart=true
 autorestart=true
-redirect_stderr=true

--- a/common/documentserver/supervisor/onlyoffice-documentserver-docservice.conf
+++ b/common/documentserver/supervisor/onlyoffice-documentserver-docservice.conf
@@ -7,4 +7,3 @@ stdout_logfile=/var/log/onlyoffice/documentserver/docservice/out.log
 stderr_logfile=/var/log/onlyoffice/documentserver/docservice/err.log
 autostart=true
 autorestart=true
-redirect_stderr=true

--- a/common/documentserver/supervisor/onlyoffice-documentserver-gc.conf
+++ b/common/documentserver/supervisor/onlyoffice-documentserver-gc.conf
@@ -7,4 +7,3 @@ stdout_logfile=/var/log/onlyoffice/documentserver/gc/out.log
 stderr_logfile=/var/log/onlyoffice/documentserver/gc/err.log
 autostart=true
 autorestart=true
-redirect_stderr=true

--- a/common/documentserver/supervisor/onlyoffice-documentserver-metrics.conf
+++ b/common/documentserver/supervisor/onlyoffice-documentserver-metrics.conf
@@ -7,4 +7,3 @@ stdout_logfile=/var/log/onlyoffice/documentserver/metrics/out.log
 stderr_logfile=/var/log/onlyoffice/documentserver/metrics/err.log
 autostart=true
 autorestart=true
-redirect_stderr=true

--- a/common/documentserver/supervisor/onlyoffice-documentserver-spellchecker.conf
+++ b/common/documentserver/supervisor/onlyoffice-documentserver-spellchecker.conf
@@ -7,4 +7,3 @@ stdout_logfile=/var/log/onlyoffice/documentserver/spellchecker/out.log
 stderr_logfile=/var/log/onlyoffice/documentserver/spellchecker/err.log
 autostart=true
 autorestart=true
-redirect_stderr=true


### PR DESCRIPTION
Since all config files have separate `stderr_logfile` entry
This cause warning on newest version of supervisor,
about that `stderr_logfile` just ignored.
And according to http://supervisord.org/configuration.html
```
redirect_stderr  (in UNIX shell terms, this is the equivalent of
executing /the/program 2>&1).
```
So if we set `stderr_logfile` no need to redirect anything