### PR TITLE
Output newline at end of shutdown warning

### DIFF
--- a/common/documentserver/bin/documentserver-prepare4shutdown.sh
+++ b/common/documentserver/bin/documentserver-prepare4shutdown.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-echo -n Preparing for shutdown, it can take a lot of time, please wait...
+echo Preparing for shutdown, it can take a lot of time, please wait...
 
 sudo -u onlyoffice \
   sh -c '\


### PR DESCRIPTION
With -n option shutdown looks like this
```
Preparing for shutdown, it can take a lot of time, please wait...[2018-09-07 16:13:46.095] [DEBUG] nodeJS - shutdown start1830000
[2018-09-07 16:13:46.133] [DEBUG] nodeJS - number of open documents 1
```