### PR TITLE
Merge develop into release/v7.2.0

### DIFF
--- a/apt-rpm/bin/documentserver-configure.sh.m4
+++ b/apt-rpm/bin/documentserver-configure.sh.m4
@@ -406,4 +406,7 @@ tune_local_configs
 
 setup_nginx
 
+# generate secure link
+documentserver-update-securelink.sh
+
 restart_services

--- a/common/documentserver/bin/documentserver-update-securelink.sh.m4
+++ b/common/documentserver/bin/documentserver-update-securelink.sh.m4
@@ -1,14 +1,36 @@
 #!/bin/sh
 
-NGINX_CONF=/etc/nginx/includes/ds-docservice.conf
-DOCSERVICE_CONF=/etc/M4_DS_PREFIX/default.json
-JSON="/var/www/M4_DS_PREFIX/npm/json -q -f ${DOCSERVICE_CONF}"
+while [ "$1" != "" ]; do
+	case $1 in
 
-SECRET_STRING=$(pwgen -s 20)
+		-s | --secure_link_secret )
+			if [ "$2" != "" ]; then
+				SECURE_LINK_SECRET=$2
+				shift
+			fi
+		;;
 
-sed "s,\(set \+\$secret_string\).*,\1 "${SECRET_STRING}";," -i ${NGINX_CONF}
+		-? | -h | --help )
+			echo "  Usage $0 [PARAMETER] [[PARAMETER], ...]"
+			echo "    Parameters:"
+			echo "      -s, --secure_link_secret               setting for secret string "
+			echo "      -?, -h, --help                    this help"
+			echo
+			exit 0
+		;;
 
-${JSON} -I -e "this.storage.fs.secretString = '${SECRET_STRING}'"
+	esac
+	shift
+done
+
+NGINX_CONF=/etc/M4_DS_PREFIX/nginx/ds.conf
+LOCAL_CONF=/etc/M4_DS_PREFIX/local.json
+JSON="/var/www/M4_DS_PREFIX/npm/json -q -f ${LOCAL_CONF}"
+
+SECURE_LINK_SECRET=${SECURE_LINK_SECRET:-$(pwgen -s 20)}
+
+sed "s,\(set \+\$secure_link_secret\).*,\1 "${SECURE_LINK_SECRET}";," -i ${NGINX_CONF}
+${JSON} -I -e 'this.storage={fs: {secretString: "'${SECURE_LINK_SECRET}'" }}' && chown ds:ds $LOCAL_CONF
 
 supervisorctl restart ds:docservice
 supervisorctl restart ds:converter

--- a/common/documentserver/nginx/ds.conf.tmpl.m4
+++ b/common/documentserver/nginx/ds.conf.tmpl.m4
@@ -3,6 +3,7 @@ server {
   listen 0.0.0.0:80;
   listen [::]:80 default_server;
   server_tokens off;
+  set $secure_link_secret verysecretstring;
   
   include M4_NGINX_CONF/ds-*.conf;
 }

--- a/common/documentserver/nginx/includes/ds-docservice.conf.m4
+++ b/common/documentserver/nginx/includes/ds-docservice.conf.m4
@@ -40,9 +40,8 @@ location ~* ^(\/cache\/files.*)(\/.*) {
   alias M4_DS_FILES/App_Data$1;
   add_header Content-Disposition "attachment; filename*=UTF-8''$arg_filename";
 
-  set $secret_string verysecretstring;
   secure_link $arg_md5,$arg_expires;
-  secure_link_md5 "$secure_link_expires$uri$secret_string";
+  secure_link_md5 "$secure_link_expires$uri$secure_link_secret";
 
   if ($secure_link = "") {
     return 403;

--- a/deb/template/package.install.m4
+++ b/deb/template/package.install.m4
@@ -1,7 +1,6 @@
 ../../common/documentserver/bin/*.sh usr/bin
 ../../common/documentserver/config/* etc/M4_DS_PREFIX
 ../../common/documentserver/home/* var/www/M4_DS_PREFIX
-../../common/documentserver/nginx/*.conf etc/M4_DS_PREFIX/nginx
 ../../common/documentserver/nginx/*.tmpl etc/M4_DS_PREFIX/nginx
 ../../common/documentserver/nginx/includes/*.conf etc/M4_DS_PREFIX/nginx/includes
 

--- a/deb/template/postinst.m4
+++ b/deb/template/postinst.m4
@@ -228,6 +228,15 @@ save_jwt_params(){
 setup_nginx(){
    DS_CONF=$CONF_DIR/nginx/ds.conf
   
+  if [ ! -e $DS_CONF ]; then
+	  cp -f ${DS_CONF}.tmpl ${DS_CONF}
+	  
+	  # generate secure link
+	  documentserver-update-securelink.sh -s $(pwgen -s 20)
+  elif ! grep -q secure_link_secret $DS_CONF; then
+	  sed '/server_tokens/a \ \ set $secure_link_secret verysecretstring;' -i $DS_CONF
+  fi
+
   db_get M4_ONLYOFFICE_VALUE/ds-port || true
   DS_PORT="$RET"
   

--- a/deb/template/prerm
+++ b/deb/template/prerm
@@ -25,6 +25,8 @@ case "$1" in
             echo "Stopping documentserver services..."
             supervisorctl stop ds:*
         fi
+        
+        unlink /etc/nginx/conf.d/ds.conf
     ;;
 
     failed-upgrade)

--- a/rpm/bin/documentserver-configure.sh.m4
+++ b/rpm/bin/documentserver-configure.sh.m4
@@ -384,4 +384,7 @@ tune_local_configs
 
 setup_nginx
 
+# generate secure link
+documentserver-update-securelink.sh
+
 restart_services

--- a/rpm/common.spec
+++ b/rpm/common.spec
@@ -261,6 +261,11 @@ case "$1" in
 esac
 
 if [ "$IS_UPGRADE" = "true" ]; then
+  NGINX_CONF=%{_sysconfdir}/%{_ds_prefix}/nginx/ds.conf
+  if [ -e $NGINX_CONF ] && ! grep -q secure_link_secret $NGINX_CONF; then
+	  sed '/server_tokens/a \ \ set $secure_link_secret verysecretstring;' -i $NGINX_CONF
+  fi
+
   DIR="/var/www/%{_ds_prefix}"
   LOCAL_CONFIG="/etc/%{_ds_prefix}/local.json"
   JSON_BIN="$DIR/npm/json"


### PR DESCRIPTION
… (#256)

* Add secret string generation in rpm\deb packages

* Remove the SECURE_LINK_SECRET variable

* Add secret string generation in apt-rpm

* Fix description error

* Change location of $secret_string

* Add secret_string parameter to an already created file

* Add secure_link parameter to debconf

* Revert "Add secret_string parameter to an already created file"

This reverts commit 48b8db1544d1745b65f0d1f070ca48842d3308e4.

* Add distribution check

* Update dist check command

* Add secret_string parameter to an already created file

* Correct errors in update-securelink file

* Remove copying of ds.conf file

* Add secure_link_secret value to debconf

* Add secret_string value to ds.conf

* Delete unnecessary code

* Delete unnecessary code

* Add secret_string value to ds.conf

* Update documentserver-update-securelink.sh.m4

* Fix minor bugs

* Rename a variable

* Change data storage file

* Replace rm with unlink

* Fix user change error

* Update documentserver-update-securelink.bat

* Fix secure_link_secret installation for deb packages

* Correct a condition

Co-authored-by: eugene-kozyrev <eugene.kozyrev@onlyoffice.com>