### PR TITLE
Generated JWT secret is too small for HMAC SHA256

### DIFF
--- a/apt-rpm/bin/documentserver-configure.sh.m4
+++ b/apt-rpm/bin/documentserver-configure.sh.m4
@@ -186,7 +186,7 @@ if [ -z $JWT_SECRET ] && [ -z $JWT_ENABLED ]; then
 fi
 
 JWT_ENABLED=${JWT_ENABLED:-true}
-JWT_SECRET=${JWT_SECRET:-$(cat /dev/urandom | tr -dc A-Za-z0-9 | head -c 12)}
+JWT_SECRET=${JWT_SECRET:-$(cat /dev/urandom | tr -dc A-Za-z0-9 | head -c 32)}
 JWT_HEADER=${JWT_HEADER:-Authorization}
 
 create_local_configs(){

--- a/deb/template/postinst.m4
+++ b/deb/template/postinst.m4
@@ -95,7 +95,7 @@ ifelse(eval(ifelse(M4_PRODUCT_NAME,documentserver-ee,1,0)||ifelse(M4_PRODUCT_NAM
 
 	if [ $JWT_ENABLED = "true" ] && [ -z $JWT_SECRET ]; then
 		JWT_MESSAGE="JWT is enabled by default. A random secret is generated automatically. Run the command '# documentserver-jwt-status.sh' to get information about JWT."
-		JWT_SECRET=$(cat /dev/urandom | tr -dc A-Za-z0-9 | head -c 12)
+		JWT_SECRET=$(cat /dev/urandom | tr -dc A-Za-z0-9 | head -c 32)
 		db_set M4_ONLYOFFICE_VALUE/jwt-secret $JWT_SECRET || true
 	elif [ $JWT_ENABLED = "false" ]; then
 		JWT_MESSAGE="You have JWT disabled. We recommend enabling JWT in ${LOCAL_CONFIG} in services.CoAuthoring.token.enable and configure your custom JWT key in services.CoAuthoring.secret"

--- a/rpm/bin/documentserver-configure.sh.m4
+++ b/rpm/bin/documentserver-configure.sh.m4
@@ -186,7 +186,7 @@ if [ -z $JWT_SECRET ] && [ -z $JWT_ENABLED ]; then
 fi
 
 JWT_ENABLED=${JWT_ENABLED:-true}
-JWT_SECRET=${JWT_SECRET:-$(cat /dev/urandom | tr -dc A-Za-z0-9 | head -c 12)}
+JWT_SECRET=${JWT_SECRET:-$(cat /dev/urandom | tr -dc A-Za-z0-9 | head -c 32)}
 JWT_HEADER=${JWT_HEADER:-Authorization}
 
 create_local_configs(){


### PR DESCRIPTION
Detailed information is provided in this pull request - https://github.com/ONLYOFFICE/Docker-DocumentServer/pull/557