### PR TITLE
🐛 fix bad links

### DIFF
--- a/common/documentserver-example/welcome/docker.html
+++ b/common/documentserver-example/welcome/docker.html
@@ -61,7 +61,7 @@
             <h3>Add it to the autostart:</h3>
             <pre>sudo docker exec $(sudo docker ps -q) sudo sed 's,autostart=false,autostart=true,' -i /etc/supervisor/conf.d/ds-example.conf</pre>
             <p>If you already installed test example, access it here:</p>
-            <a href="/example/">
+            <a href="../example">
                 <div class="button">GO TO TEST EXAMPLE</div>
             </a>
             <p>Please do NOT use a test example on your own server without proper code modifications. It is intended for testing purposes only and must be disabled before launching the editors into production.</p>

--- a/common/documentserver-example/welcome/k8s.html
+++ b/common/documentserver-example/welcome/k8s.html
@@ -49,7 +49,7 @@
         <div class="content-block">
             <h1>Testing before integration</h1>
             <p>If you already installed test example, access it here:</p>
-            <a href="/example/">
+            <a href="../example">
                 <div class="button">GO TO TEST EXAMPLE</div>
             </a>
             <p></p>

--- a/common/documentserver-example/welcome/linux-rpm.html
+++ b/common/documentserver-example/welcome/linux-rpm.html
@@ -60,7 +60,7 @@
             <h3>Add it to the autostart:</h3>
             <pre>sudo systemctl enable ds-example</pre>
             <p>If you already installed test example, access it here:</p>
-            <a href="/example/">
+            <a href="../example">
                 <div class="button">GO TO TEST EXAMPLE</div>
             </a>
             <p>Please do NOT use a test example on your own server without proper code modifications. It is intended for testing purposes only and must be disabled before launching the editors into production.</p>

--- a/common/documentserver-example/welcome/linux.html
+++ b/common/documentserver-example/welcome/linux.html
@@ -60,7 +60,7 @@
             <h3>Add it to the autostart:</h3>
             <pre>sudo systemctl enable ds-example</pre>
             <p>If you already installed test example, access it here:</p>
-            <a href="/example/">
+            <a href="../example">
                 <div class="button">GO TO TEST EXAMPLE</div>
             </a>
             <p>Please do NOT use a test example on your own server without proper code modifications. It is intended for testing purposes only and must be disabled before launching the editors into production.</p>

--- a/common/documentserver-example/welcome/win.html
+++ b/common/documentserver-example/welcome/win.html
@@ -62,7 +62,7 @@
             <h3>Add it to the autostart:</h3>
             <pre>sc config DsExampleSvc start=auto</pre>
             <p>If you already installed test example, access it here:</p>
-            <a href="/example/">
+            <a href="../example">
                 <div class="button">GO TO TEST EXAMPLE</div>
             </a>
             <p>Please do NOT use a test example on your own server without proper code modifications. It is intended for testing purposes only and must be disabled before launching the editors into production.</p>


### PR DESCRIPTION
This merge request corrects bad links in the backend by replacing occurrences of `<a href="/example/">` with `<a href="../example">`. This change ensures that links are resolved against the current path instead of being resolved against the root path, which was causing links to break. The fix will improve the user experience by ensuring that links work as intended, providing a better browsing experience.