### PR TITLE
Added deb-dependencies target to Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -573,3 +573,5 @@ deploy-bin: $(DS_BIN)
 	aws s3 sync --no-progress --acl public-read \
 		$(DS_BIN_REPO) \
 		s3://$(S3_BUCKET)/$(PLATFORM)/ds-bin/$(GIT_BRANCH)/$(PRODUCT_VERSION)/
+
+deb-dependencies: $(DEB_DEPS)


### PR DESCRIPTION
This new deb-dependencies target from Makefile allows you to install source package dependencies in Debian.

Example:

```
make deb-dependencies
cd deb/build
apt build-dep ./
```
.

Related issue: https://github.com/ONLYOFFICE/document-server-package/issues/355 which I think it wouldn't be fixed by this commit. Why? Because there is not an official recipe on how to package a deb file from scratch.