### PR TITLE
fix Bug 68016 - Enable underscores in NGINX headers

### DIFF
--- a/common/documentserver/nginx/includes/ds-common.conf.m4
+++ b/common/documentserver/nginx/includes/ds-common.conf.m4
@@ -1,6 +1,8 @@
 ## Increase this if you want to upload large attachments
 client_max_body_size 100m;
 
+underscores_in_headers on;
+
 gzip on;
 gzip_vary on;
 gzip_types  text/plain
@@ -19,4 +21,3 @@ gzip_types  text/plain
 
 access_log off;
 error_log M4_NGINX_LOG/nginx.error.log;
-underscores_in_headers on;

--- a/common/documentserver/nginx/includes/ds-common.conf.m4
+++ b/common/documentserver/nginx/includes/ds-common.conf.m4
@@ -19,3 +19,4 @@ gzip_types  text/plain
 
 access_log off;
 error_log M4_NGINX_LOG/nginx.error.log;
+underscores_in_headers on;


### PR DESCRIPTION
Adding the underscores_in_headers ON directive allows us to pass a JWT header containing an underscore (_)