### PR TITLE
nginx: Raise gzip_min_length from default 20 bytes to 48 bytes

### DIFF
--- a/common/documentserver/nginx/includes/ds-common.conf.m4
+++ b/common/documentserver/nginx/includes/ds-common.conf.m4
@@ -5,6 +5,7 @@ underscores_in_headers on;
 
 gzip on;
 gzip_vary on;
+gzip_min_length 48;
 gzip_types  text/plain
             text/xml
             text/css


### PR DESCRIPTION
This patch will reduce overhead introduced by compressing too small bodies