### PR TITLE
Updated link for signature

### DIFF
--- a/common/documentserver-example/welcome/docker.html
+++ b/common/documentserver-example/welcome/docker.html
@@ -50,7 +50,7 @@
         <p class="notice_text">A random secret is generated automatically if a custom secret has not been added during installation. To obtain the default secret, run this command:</p>
         <pre> sudo docker exec $(sudo docker ps -q) /var/www/onlyoffice/documentserver/npm/json -f /etc/onlyoffice/documentserver/local.json 'services.CoAuthoring.secret.session.string'</span></pre>
         <p class="notice_text notice_margin">You can replace the default secret with a custom key using Docker env.</p>
-        <p class="notice_text notice_margin">More information about JWT in the <a href="https://api.onlyoffice.com/editors/signature/">documentation.</a></p>
+        <p class="notice_text notice_margin">More information about JWT in the <a href="https://api.onlyoffice.com/docs/docs-api/additional-api/signature/">documentation.</a></p>
     </div>
     <div>
         <div class="content-block">

--- a/common/documentserver-example/welcome/linux-rpm.html
+++ b/common/documentserver-example/welcome/linux-rpm.html
@@ -49,7 +49,7 @@
         <h1>Starting from version 7.2,  JWT is enabled by default.</h1> <br>
         <p class="notice_text">A random secret is generated automatically if a custom secret has not been added during installation.</p>
         <p class="notice_text">The secret is available in - <em>/etc/onlyoffice/documentserver/<b>local.json</b></em> in - <em>services.CoAuthoring.secret.browser.string</em> parameter.</p>
-        <p class="notice_text">If you want to replace the default secret with a custom key, read the <a href="https://api.onlyoffice.com/editors/signature/">documentation.</a></p>
+        <p class="notice_text">If you want to replace the default secret with a custom key, read the <a href="https://api.onlyoffice.com/docs/docs-api/additional-api/signature/">documentation.</a></p>
     </div>
     <div>
         <div class="content-block">

--- a/common/documentserver-example/welcome/linux.html
+++ b/common/documentserver-example/welcome/linux.html
@@ -49,7 +49,7 @@
         <h1>Starting from version 7.2,  JWT is enabled by default.</h1> <br>
         <p class="notice_text">A random secret is generated automatically if a custom secret has not been added during installation.</p>
         <p class="notice_text">The secret is available in - <em>/etc/onlyoffice/documentserver/<b>local.json</b></em> in - <em>services.CoAuthoring.secret.browser.string</em> parameter.</p>
-        <p class="notice_text">If you want to replace the default secret with a custom key, read the <a href="https://api.onlyoffice.com/editors/signature/">documentation.</a></p>
+        <p class="notice_text">If you want to replace the default secret with a custom key, read the <a href="https://api.onlyoffice.com/docs/docs-api/additional-api/signature/">documentation.</a></p>
     </div>
     <div>
         <div class="content-block">

--- a/common/documentserver-example/welcome/win.html
+++ b/common/documentserver-example/welcome/win.html
@@ -51,7 +51,7 @@
         <h1>Starting from version 7.2,  JWT is enabled by default.</h1> <br>
         <p class="notice_text">A random secret is generated automatically if a custom secret has not been added during installation.<br>The secret is available in - <em>%ProgramFiles%\ONLYOFFICE\DocumentServer\config\<b>local.json</b></em></p>        
         <p class="notice_text">in - <em>services.CoAuthoring.secret.browser.string</em> parameter.</p>
-        <p class="notice_text">If you want to replace the default secret with a custom key, read the <a href="https://api.onlyoffice.com/editors/signature/">documentation.</a></p>
+        <p class="notice_text">If you want to replace the default secret with a custom key, read the <a href="https://api.onlyoffice.com/docs/docs-api/additional-api/signature/">documentation.</a></p>
     </div>
     <div>
         <div class="content-block">


### PR DESCRIPTION
Current link leads to https://api.onlyoffice.com/editors/signature/ (404).

I believe it's supposed to lead to the https://api.onlyoffice.com/docs/docs-api/additional-api/signature/